### PR TITLE
Point assistant adapter to Next API route

### DIFF
--- a/src/services/assistantAdapter.ts
+++ b/src/services/assistantAdapter.ts
@@ -74,8 +74,10 @@ const mockHandler: ChatHandler = async ({ prompt, language, signal }) => {
   };
 };
 
+const ASSISTANT_API_URL = process.env.NEXT_PUBLIC_ASSISTANT_API_URL || "/api/assistant";
+
 const apiHandler: ChatHandler = async ({ prompt, language, signal }) => {
-  const response = await fetch("/chat/stream", {
+  const response = await fetch(ASSISTANT_API_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- update the assistant adapter to call the Next.js proxy route instead of the missing /chat/stream endpoint
- allow overriding the assistant API URL via NEXT_PUBLIC_ASSISTANT_API_URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deca93f350832c916d38c206794509